### PR TITLE
Improve testing; resolve deprecations and linter issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ script:
   - tox
 env:
   - TOXENV=linters
-  - TOXENV=functional
+  - TOXENV=functional_1.9.4
+  - TOXENV=functional_2.1.0
+  - TOXENV=functional_stable
 notifications:
   slack:
     rooms:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+bird_package_state: latest
+
 bird_gpg_keys:
   - key_name: 'bird'
     keyserver: 'hkp://keyserver.ubuntu.com:80'

--- a/tasks/bird_install.yml
+++ b/tasks/bird_install.yml
@@ -27,11 +27,11 @@
 - name: Install bird apt packages
   apt:
     pkg: "{{ item }}"
-    state: latest
+    state: "{{ bird_package_state }}"
   register: install_packages
   until: install_packages|success
   retries: 5
   delay: 2
-  with_items: bird_apt_packages
+  with_items: "{{ bird_apt_packages }}"
   tags:
     - bird-apt-packages

--- a/tasks/bird_post_install.yml
+++ b/tasks/bird_post_install.yml
@@ -91,7 +91,7 @@
     name: "{{ item.item.service }}"
     state: restarted
   when: item.changed
-  with_items: bird_results.results
+  with_items: "{{ bird_results.results }}"
   tags:
     - upstart-init
     - bird-init

--- a/tasks/bird_pre_install.yml
+++ b/tasks/bird_pre_install.yml
@@ -19,7 +19,7 @@
     keyserver: "{{ item.keyserver | default(omit) }}"
     data: "{{ item.data | default(omit) }}"
     state: "present"
-  with_items: bird_gpg_keys
+  with_items: "{{ bird_gpg_keys }}"
   register: add_keys
   until: add_keys|success
   retries: 5
@@ -36,7 +36,7 @@
   until: add_keys_fallback|success
   retries: 5
   delay: 2
-  with_items: bird_gpg_keys
+  with_items: "{{ bird_gpg_keys }}"
   when: add_keys|failed and item.fallback_keyserver is defined
   tags:
     - bird-apt-keys

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.0
 skipsdist = True
-envlist = linters,functional
+envlist = linters,functional_1.9.4,functional_2.1.0,functional_stable
 
 
 [testenv]
@@ -103,8 +103,6 @@ commands =
 [testenv:ansible]
 deps =
     {[testenv]deps}
-    ansible==1.9.4
-    ansible-lint>=2.7.0,<3.0.0
 setenv =
     {[testenv]setenv}
     ANSIBLE_HOST_KEY_CHECKING = False
@@ -131,14 +129,41 @@ commands =
                    --role-file={toxinidir}/tests/ansible-role-requirements.yml \
                    --force
 
-
-[testenv:ansible-syntax]
+[testenv:ansible_1.9.4]
 deps =
     {[testenv:ansible]deps}
+    ansible==1.9.4
 setenv =
     {[testenv:ansible]setenv}
 commands =
     {[testenv:ansible]commands}
+
+[testenv:ansible_2.1.0]
+deps =
+    {[testenv:ansible]deps}
+    ansible==2.1.0
+setenv =
+    {[testenv:ansible]setenv}
+commands =
+    {[testenv:ansible]commands}
+
+[testenv:ansible_stable]
+deps =
+    {[testenv:ansible]deps}
+    ansible
+    ansible-lint
+setenv =
+    {[testenv:ansible]setenv}
+commands =
+    {[testenv:ansible]commands}
+
+[testenv:ansible-syntax]
+deps =
+    {[testenv:ansible_stable]deps}
+setenv =
+    {[testenv:ansible_stable]setenv}
+commands =
+    {[testenv:ansible_stable]commands}
     ansible-playbook -i {toxinidir}/tests/inventory \
                      --syntax-check \
                      --list-tasks \
@@ -148,34 +173,61 @@ commands =
 
 [testenv:ansible-lint]
 deps =
-    {[testenv:ansible]deps}
+    {[testenv:ansible_stable]deps}
 commands =
     ansible-lint {toxinidir}
 
 
-[testenv:functional]
-# NOTE(odyssey4me): this target does not use constraints because
-# it doesn't work in OpenStack-CI yet. Once that's fixed, we can
-# drop the install_command.
+[testenv:functional_1.9.4]
 install_command =
     pip install -U --force-reinstall {opts} {packages}
 deps =
-    {[testenv:ansible]deps}
+    {[testenv:ansible_1.9.4]deps}
 setenv =
-    {[testenv:ansible]setenv}
+    {[testenv:ansible_1.9.4]setenv}
 commands =
-    {[testenv:ansible]commands}
+    {[testenv:ansible_1.9.4]commands}
     ansible-playbook -i {toxinidir}/tests/inventory \
                      -e "rolename={toxinidir}" \
                      -e "install_test_packages=True" \
                      {toxinidir}/tests/test.yml -vvvv
 
 
+[testenv:functional_2.1.0]
+install_command =
+   pip install -U --force-reinstall {opts} {packages}
+deps =
+   {[testenv:ansible_2.1.0]deps}
+setenv =
+   {[testenv:ansible_2.1.0]setenv}
+commands =
+   {[testenv:ansible_2.1.0]commands}
+   ansible-playbook -i {toxinidir}/tests/inventory \
+                    -e "rolename={toxinidir}" \
+                    -e "install_test_packages=True" \
+                    {toxinidir}/tests/test.yml -vvvv
+
+
+[testenv:functional_stable]
+install_command =
+   pip install -U --force-reinstall {opts} {packages}
+deps =
+   {[testenv:ansible_stable]deps}
+setenv =
+   {[testenv:ansible_stable]setenv}
+commands =
+   {[testenv:ansible_stable]commands}
+   ansible-playbook -i {toxinidir}/tests/inventory \
+                    -e "rolename={toxinidir}" \
+                    -e "install_test_packages=True" \
+                    {toxinidir}/tests/test.yml -vvvv
+
+
 [testenv:linters]
 deps =
-    {[testenv:ansible]deps}
+    {[testenv:ansible_stable]deps}
 setenv =
-    {[testenv:ansible]setenv}
+    {[testenv:ansible_stable]setenv}
 commands =
     {[testenv:pep8]commands}
     {[testenv:bashate]commands}


### PR DESCRIPTION
Adds tox scenarios for ansible 1.9.4, 2.1.0, and latest stable.

Runs linter using latest stable ansible.

Resolves var deprecations and linter issues

This resolves #3
