### PR TITLE
Rename BIRD router ID variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,7 +31,7 @@ bird_apt_repo:
 bird_apt_packages:
   - bird
 
-bird_bgp_router_id: "{{ ansible_default_ipv4['address'] }}"
+bird_router_id: "{{ ansible_default_ipv4['address'] }}"
 
 # Auto-enable bird/bird6 if an ipv4/ipv6 default route is present
 # Set to true/false to override auto detection

--- a/templates/bird-common.conf.j2
+++ b/templates/bird-common.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-router id {{ bird_bgp_router_id }};
+router id {{ bird_router_id }};
 
 {% for include in item.includes %}
 include "{{ include }}";


### PR DESCRIPTION
bird_bgp_router_id is now bird_router_id. The variable is a global option,
not anything BGP specific, and was named incorrectly.
