### PR TITLE
Use COPR repo for EL7 install

### DIFF
--- a/tasks/bird_install_yum.yml
+++ b/tasks/bird_install_yum.yml
@@ -16,32 +16,28 @@
 - name: Add BIRD yum key
   rpm_key:
     state: present
-    key: "{{ item.url }}"
+    key: "{{ bird_keys }}"
   register: add_keys
   until: add_keys|success
   retries: 5
   delay: 2
-  with_items: "{{ bird_keys }}"
   when: "{{ bird_package_source == 'bird' }}"
   tags:
     - bird-keys
 
-#TODO(logan) Remove this task once we move to Ansible 2.1
-# where we can leverage the `yum_repository` module:
-# https://docs.ansible.com/ansible/yum_repository_module.html
 - name: Add BIRD repo
-  copy:
-    content: |
-      [{{ item.name }}]
-      name={{ item.name }}
-      description={{ item.description }}
-      baseurl={{ item.baseurl }}
-      gpgkey={{ item.gpgkey }}
-      gpgcheck=1
-      enabled=1
-    dest: "/etc/yum.repos.d/{{ item.file }}.repo"
+  yum_repository:
+    name: "{{ item.name }}"
+    description: "{{ item.description }}"
+    baseurl: "{{ item.baseurl }}"
+    enabled: "{{ item.enabled | default(omit) }}"
+    gpgcheck: "{{ item.gpgcheck | default(True) }}"
+    gpgkey: "{{ item.gpgkey }}"
+    repo_gpgcheck: "{{ item.repo_gpgcheck | default(omit) }}"
+    priority: "{{ item.priority | default(omit) }}"
+    state: "{{ item.state | default(omit) }}"
   register: add_repos
-  until: add_repos|success
+  until: add_repos | success
   retries: 5
   delay: 2
   with_items:

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -19,17 +19,15 @@ bird_package_source: bird
 #bird configurations are stored in /etc on RHEL instead of /etc/bird
 bird_conf_dir: /etc
 
-bird_keys:
-  - url: http://rpm.knot-dns.cz/redhat/RPM-GPG-KEY-network.cz
+bird_keys: https://copr-be.cloud.fedoraproject.org/results/logan2211/bird/pubkey.gpg
 
-bird_yum_repo_url: http://rpm.knot-dns.cz/redhat/
+bird_yum_repo_url: https://copr-be.cloud.fedoraproject.org/results/logan2211/bird/epel-7-$basearch/
 bird_repo:
   state: present
   name: bird
-  description: Network.CZ Repository
-  file: bird
+  description: COPR repository for BIRD packages on CentOS 7
   baseurl: "{{ bird_yum_repo_url }}"
-  gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-network.cz
+  gpgkey: "{{ bird_keys }}"
 
 
 bird_required_packages:


### PR DESCRIPTION
The upstream BIRD RPMs do not support installation on EL7 systems,
they are built for Fedora only and the dependencies are not present
on EL7 repos or EPEL.

To get EL7 installation working, I created a COPR repo to create
automatic RPM builds for EL6 and EL7 systems based on the upstream
SRPM files.

The COPR repo is available here:
https://copr.fedorainfracloud.org/coprs/logan2211/bird/ and will be
used as the default BIRD repo for EL7 installations.

EPEL installation is still available however the version in EPEL is
so outdated it is probably insufficient for many modern uses of BIRD.