### PR TITLE
Add support for openSUSE Leap distributions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,11 @@ env:
       TOXENV=functional_stable
       docker_image_tag=centos-7
       CACHE_NAME=cent7
-# No opensuse support yet
-#    - >
-#      TOXENV=functional_stable
-#      docker_image_tag=opensuse-42.2
-#      CACHE_NAME=suse42
-#      docker_command=/usr/lib/systemd/systemd
+    - >
+      TOXENV=functional_stable
+      docker_image_tag=opensuse-42.2
+      CACHE_NAME=suse42
+      docker_command=/usr/lib/systemd/systemd
 before_install:
   # Load cached docker images
   - if [[ -d ${cache_dir} ]]; then ls ${cache_dir}/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,14 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - trusty
+    - name: EL
+      versions:
+        - 7
+    - name: opensuse
+      versions:
+        - 42.1
+        - 42.2
+        - 42.3
   categories:
     - networking
     - bgp

--- a/tasks/bird_install.yml
+++ b/tasks/bird_install.yml
@@ -26,3 +26,10 @@
     - ansible_pkg_mgr == 'yum'
   tags:
     - install-yum
+
+- include: bird_install_zypper.yml
+  static: no
+  when:
+    - ansible_pkg_mgr == 'zypper'
+  tags:
+    - install-zypper

--- a/tasks/bird_install_zypper.yml
+++ b/tasks/bird_install_zypper.yml
@@ -1,0 +1,57 @@
+---
+# Copyright 2016, Logan Vig <logan2211@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Add BIRD yum key
+  rpm_key:
+    state: present
+    key: "{{ bird_keys }}"
+  register: add_keys
+  until: add_keys|success
+  retries: 5
+  delay: 2
+  when: "{{ bird_package_source == 'bird' }}"
+  tags:
+    - bird-keys
+
+- name: Add BIRD repo
+  zypper_repository:
+    name: "{{ item.name }}"
+    description: "{{ item.description }}"
+    autorefresh: yes
+    repo: "{{ item.baseurl }}"
+    enabled: "{{ item.enabled | default(omit) }}"
+    priority: "{{ item.priority | default(omit) }}"
+    state: "{{ item.state | default(omit) }}"
+  register: add_repos
+  until: add_repos | success
+  retries: 5
+  delay: 2
+  with_items:
+    - "{{ bird_repo }}"
+  when: "{{ bird_package_source == 'bird' }}"
+  tags:
+    - bird-repos
+
+- name: Install BIRD zypper packages
+  zypper:
+    name: "{{ item }}"
+    state: "{{ bird_package_state }}"
+  register: install_packages
+  until: install_packages|success
+  retries: 5
+  delay: 2
+  with_items: "{{ bird_packages }}"
+  tags:
+    - bird-zypper-packages

--- a/vars/suse.yml
+++ b/vars/suse.yml
@@ -1,0 +1,43 @@
+---
+# Copyright 2016, Logan Vig <logan2211@gmail.com>
+# Copyright 2017, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bird_package_source: bird
+
+# NOTE(hwoarang): openSUSE does not have a bird package easily available so we
+# use the same repository with RedHat.
+
+#bird configurations are stored in /etc on RHEL instead of /etc/bird
+bird_conf_dir: /etc
+
+bird_keys: https://copr-be.cloud.fedoraproject.org/results/logan2211/bird/pubkey.gpg
+
+bird_yum_repo_url: https://copr-be.cloud.fedoraproject.org/results/logan2211/bird/epel-7-x86_64/
+bird_repo:
+  state: present
+  name: bird
+  description: COPR repository for BIRD packages on CentOS 7
+  baseurl: "{{ bird_yum_repo_url }}"
+  gpgkey: "{{ bird_keys }}"
+
+
+bird_required_packages: []
+
+bird_packages:
+  - bird
+
+#RHEL uses a combined systemd unit for bird/bird6 called "bird" which manages
+#both daemons.
+bird_ipv6_enabled: skip


### PR DESCRIPTION
openSUSE Leap does not have a bird package in the official distribution
or development repositories so we use the one from CentOS7.