### PR TITLE
Gather updated network facts before config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,11 @@ bird_conf_dir: /etc/bird
 
 bird_router_id: "{{ ansible_default_ipv4['address'] }}"
 
+# Force an update of the network facts before building the configuration
+# This is useful when protocol auto detection is used, because the network may
+# have changed since facts were last gathered if they have been cached a while.
+bird_gather_net_facts: yes
+
 # Auto-enable bird/bird6 if an ipv4/ipv6 default route is present
 # Set to true/false to override auto detection
 bird_ipv4_enabled: detect

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,4 +25,11 @@
     - always
 
 - include: bird_install.yml
+
+- name: Gather updated network facts
+  setup:
+    gather_subset: '!all,network'
+  when:
+    - bird_gather_net_facts | bool
+
 - include: bird_post_install.yml


### PR DESCRIPTION
If facts have been cached for a while, BIRD configuration could be
generated based on outdated fact information.