### PR TITLE
Disable repo metadata gpg check on suse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ env:
       CACHE_NAME=cent7
     - >
       TOXENV=functional_stable
-      docker_image_tag=opensuse-42.2
+      docker_image_tag=opensuse-42.3
       CACHE_NAME=suse42
       docker_command=/usr/lib/systemd/systemd
 before_install:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,8 +28,6 @@ galaxy_info:
         - 7
     - name: opensuse
       versions:
-        - 42.1
-        - 42.2
         - 42.3
   categories:
     - networking

--- a/tasks/bird_install_zypper.yml
+++ b/tasks/bird_install_zypper.yml
@@ -44,6 +44,16 @@
   tags:
     - bird-repos
 
+- name: Disable repo metadata GPG check for BIRD
+  command: "zypper mr --gpgcheck-allow-unsigned-repo --refresh {{ item.name }}"
+  with_items:
+    - "{{ bird_repo }}"
+  when:
+    - bird_package_source == 'bird'
+    - not item.repo_gpg_check | default('yes') | bool
+  tags:
+    - bird-repos
+
 - name: Install BIRD zypper packages
   zypper:
     name: "{{ item }}"

--- a/vars/suse.yml
+++ b/vars/suse.yml
@@ -31,6 +31,7 @@ bird_repo:
   description: COPR repository for BIRD packages on CentOS 7
   baseurl: "{{ bird_yum_repo_url }}"
   gpgkey: "{{ bird_keys }}"
+  repo_gpg_check: no
 
 
 bird_required_packages: []


### PR DESCRIPTION
Since COPR does not sign its repodata files, this causes zypper to
fail out when attempting to install the bird packages.